### PR TITLE
fix: Fix release workflow version detection logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,16 +67,45 @@ jobs:
           echo "Current version: $current_version"
           
           # Analyze changelog to determine bump type
-          major_changes=$(sed -n '/## \[Unreleased\]/,/## \[/p' CHANGELOG.md | grep -E "^### (Removed)" || true)
-          minor_changes=$(sed -n '/## \[Unreleased\]/,/## \[/p' CHANGELOG.md | grep -E "^### (Added|Changed|Deprecated)" || true)
-          patch_changes=$(sed -n '/## \[Unreleased\]/,/## \[/p' CHANGELOG.md | grep -E "^### (Fixed|Security)" || true)
+          # Extract the Unreleased section
+          unreleased_section=$(sed -n '/## \[Unreleased\]/,/## \[/p' CHANGELOG.md)
           
-          # Determine bump type (check in order: major -> minor -> patch)
-          if [ -n "$major_changes" ]; then
+          # Check for sections with actual entries (lines starting with -)
+          major_entries=""
+          minor_entries=""
+          patch_entries=""
+          
+          # Check if Removed section has entries
+          if echo "$unreleased_section" | grep -q "^### Removed"; then
+            major_entries=$(echo "$unreleased_section" | sed -n '/### Removed/,/^###\|^##/p' | grep "^- " || true)
+          fi
+          
+          # Check if Added/Changed/Deprecated sections have entries
+          for section in "Added" "Changed" "Deprecated"; do
+            if echo "$unreleased_section" | grep -q "^### $section"; then
+              section_entries=$(echo "$unreleased_section" | sed -n "/### $section/,/^###\|^##/p" | grep "^- " || true)
+              if [ -n "$section_entries" ]; then
+                minor_entries="$minor_entries$section_entries"
+              fi
+            fi
+          done
+          
+          # Check if Fixed/Security sections have entries
+          for section in "Fixed" "Security"; do
+            if echo "$unreleased_section" | grep -q "^### $section"; then
+              section_entries=$(echo "$unreleased_section" | sed -n "/### $section/,/^###\|^##/p" | grep "^- " || true)
+              if [ -n "$section_entries" ]; then
+                patch_entries="$patch_entries$section_entries"
+              fi
+            fi
+          done
+          
+          # Determine bump type based on actual entries
+          if [ -n "$major_entries" ]; then
             bump_type="major"
-          elif [ -n "$minor_changes" ]; then
+          elif [ -n "$minor_entries" ]; then
             bump_type="minor"
-          elif [ -n "$patch_changes" ]; then
+          elif [ -n "$patch_entries" ]; then
             bump_type="patch"
           else
             # Default to patch if only individual items without category

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI/CD pipeline with GitHub Actions
 - Support for Python 3.11, 3.12, and 3.13
 
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
-
 [Unreleased]: https://github.com/SecDev-Lab/sprout/compare/v0.1.0...HEAD


### PR DESCRIPTION
## Summary
- Fixed incorrect version bump detection that caused 0.1.0 → 1.0.0 instead of 0.1.0 → 0.2.0
- Improved changelog parsing to check for actual entries, not just section headers

## Problem
The release workflow was detecting empty `### Removed` section as a major version bump, resulting in version 1.0.0 instead of the expected 0.2.0.

## Solution
1. **Updated version detection logic** in `.github/workflows/release.yml`:
   - Now checks for actual entries (lines starting with `-`) within each section
   - Empty sections are ignored
   - Only sections with content trigger version bumps

2. **Cleaned up CHANGELOG.md**:
   - Removed empty sections (Changed, Deprecated, Removed, Fixed, Security)
   - Keep only sections with actual content

## Testing
After merge, the next release should correctly detect:
- `### Added` section has entries → Minor version bump (0.1.0 → 0.2.0)
- Empty sections are ignored

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>