### PR TITLE
feat: Enable sprout to work without .env.example files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for multiple `.env.example` files throughout the repository, enabling monorepo workflows
 - Recursive scanning of `.env` files for port allocation to ensure global uniqueness across all services
+- Support for repositories without `.env.example` files - `sprout create` now works in any git repository
 
 ### Changed
 - Port allocation now ensures uniqueness across all services in all worktrees, preventing Docker host port conflicts
 - `sprout create` now processes all `.env.example` files found in the repository while maintaining directory structure
 - Only git-tracked `.env.example` files are now processed, preventing unwanted processing of files in `.sprout/` worktrees
+- `sprout create` behavior when no `.env.example` files exist: shows warning instead of error and continues creating worktree
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support for repositories without `.env.example` files - `sprout create` now works in any git repository
 
 ### Changed
+- `sprout create` behavior when no `.env.example` files exist: shows warning instead of error and continues creating worktree
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ pip install -e ".[dev]"
 
 ## Quick Start
 
-1. Create a `.env.example` template in your project root (and optionally in subdirectories):
+**Note**: Sprout works in any git repository. `.env.example` files are optional - if you don't have them, sprout will simply create worktrees without `.env` generation.
+
+1. (Optional) Create a `.env.example` template in your project root (and optionally in subdirectories) for automatic `.env` generation:
 ```env
 # API Configuration
 API_KEY={{ API_KEY }}
@@ -58,9 +60,13 @@ repo/
 cd $(sprout create feature-branch --path)
 ```
 
+**What happens when you run `sprout create`:**
+- If `.env.example` files exist: Sprout will generate corresponding `.env` files with populated variables and unique port assignments
+- If no `.env.example` files exist: Sprout will show a warning and create the worktree without `.env` generation
+
 This single command:
 - Creates a new git worktree for `feature-branch`
-- Generates a `.env` file from your template
+- Generates `.env` files from your templates (if `.env.example` files exist)
 - Outputs the path to the new environment
 - Changes to that directory when wrapped in `cd $(...)`
 

--- a/docs/sprout-cli/overview.md
+++ b/docs/sprout-cli/overview.md
@@ -8,9 +8,10 @@
 
 ### 1. Automated Development Environment Setup
 - Create git worktrees
-- Automatically generate `.env` files from `.env.example` templates
+- Automatically generate `.env` files from `.env.example` templates (when templates exist)
 - Automatic port number assignment (collision avoidance)
 - Interactive environment variable configuration
+- Works in any git repository, with or without `.env.example` files
 
 ### 2. Unified Management
 - Centralize all worktrees in `.sprout/` directory
@@ -42,9 +43,9 @@
 ├── .git/
 ├── .sprout/              # sprout management directory
 │   └── <branch-name>/    # each worktree
-│       ├── .env          # auto-generated environment config
+│       ├── .env          # auto-generated environment config (if .env.example exists)
 │       └── ...           # source code
-├── .env.example          # template
+├── .env.example          # template (optional)
 └── compose.yaml          # Docker Compose config
 ```
 

--- a/docs/sprout-cli/usage.md
+++ b/docs/sprout-cli/usage.md
@@ -22,9 +22,11 @@ sprout create feature-branch
 
 This command performs:
 1. Creates worktree in `.sprout/feature-branch`
-2. Generates `.env` from `.env.example` template
-3. Prompts for required environment variables
-4. Automatically assigns port numbers
+2. Generates `.env` from `.env.example` template (if template exists)
+3. Prompts for required environment variables (if `.env.example` exists)
+4. Automatically assigns port numbers (if `.env.example` exists)
+
+**Note**: If no `.env.example` files are found, sprout will show a warning but continue creating the worktree without `.env` generation.
 
 ### 2. List Development Environments
 
@@ -177,8 +179,14 @@ REDIS_PORT={{ auto_port() }}    # Might assign 3003
 - Execute from Git repository root directory
 - Ensure `.git` directory exists
 
-### ".env.example file not found" Error
-- Create `.env.example` in project root
+### Working Without .env.example Files
+As of recent versions, sprout works perfectly fine without `.env.example` files:
+- If no `.env.example` files exist, sprout will show a warning but continue
+- The worktree will be created successfully without `.env` generation
+- This is useful for projects that don't need environment variable templating
+
+If you want to add `.env` generation later:
+- Create `.env.example` in project root or subdirectories  
 - Use the template syntax described above
 
 ### "Could not find an available port" Error

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -144,6 +144,7 @@ class TestCreateCommand:
 
         # Change to project directory to make relative path calculation work
         import os
+
         old_cwd = os.getcwd()
         os.chdir(str(mock_git_root))
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -126,20 +126,36 @@ class TestCreateCommand:
         # stdout should be empty
         assert result.stdout == ""
 
-    def test_create_no_env_example(self, mocker):
-        """Test error when .env.example doesn't exist."""
+    def test_create_no_env_example(self, mocker, tmp_path):
+        """Test success when .env.example doesn't exist."""
         mocker.patch("sprout.commands.create.is_git_repository", return_value=True)
-        mock_git_root = Path("/project")
+        mock_git_root = tmp_path / "project"
+        mock_git_root.mkdir()
         mocker.patch("sprout.commands.create.get_git_root", return_value=mock_git_root)
+        mocker.patch("sprout.commands.create.worktree_exists", return_value=False)
+        sprout_dir = tmp_path / ".sprout"
+        sprout_dir.mkdir()
+        mocker.patch("sprout.commands.create.ensure_sprout_dir", return_value=sprout_dir)
+        mocker.patch("sprout.commands.create.branch_exists", return_value=False)
 
-        # Mock git ls-files to return empty list
+        # Mock git ls-files to return empty list (no .env.example files)
         mock_run = mocker.patch("sprout.commands.create.run_command")
         mock_run.return_value = Mock(stdout="", returncode=0)
 
-        result = runner.invoke(app, ["create", "feature-branch"])
+        # Change to project directory to make relative path calculation work
+        import os
+        old_cwd = os.getcwd()
+        os.chdir(str(mock_git_root))
 
-        assert result.exit_code == 1
-        assert "No .env.example files found" in result.stdout
+        try:
+            result = runner.invoke(app, ["create", "feature-branch"])
+
+            assert result.exit_code == 0
+            assert "Warning: No .env.example files found" in result.stdout
+            assert "Workspace 'feature-branch' created successfully!" in result.stdout
+            assert "No .env files generated (no .env.example templates found)" in result.stdout
+        finally:
+            os.chdir(old_cwd)
 
     def test_create_worktree_exists(self, mocker):
         """Test error when worktree already exists."""
@@ -160,6 +176,28 @@ class TestCreateCommand:
 
         assert result.exit_code == 1
         assert "Worktree for branch 'feature-branch' already exists" in result.stdout
+
+    def test_create_without_env_example_path_mode(self, mocker, tmp_path):
+        """Test path mode with no .env.example files."""
+        mocker.patch("sprout.commands.create.is_git_repository", return_value=True)
+        mock_git_root = tmp_path / "project"
+        mock_git_root.mkdir()
+        mocker.patch("sprout.commands.create.get_git_root", return_value=mock_git_root)
+        mocker.patch("sprout.commands.create.worktree_exists", return_value=False)
+        sprout_dir = tmp_path / ".sprout"
+        sprout_dir.mkdir()
+        mocker.patch("sprout.commands.create.ensure_sprout_dir", return_value=sprout_dir)
+        mocker.patch("sprout.commands.create.branch_exists", return_value=False)
+
+        # Mock git ls-files to return empty list (no .env.example files)
+        mock_run = mocker.patch("sprout.commands.create.run_command")
+        mock_run.return_value = Mock(stdout="", returncode=0)
+
+        result = runner.invoke(app, ["create", "feature-branch", "--path"])
+
+        assert result.exit_code == 0
+        # In path mode, only the path should be printed to stdout
+        assert result.stdout.strip() == str(sprout_dir / "feature-branch")
 
 
 class TestLsCommand:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -223,11 +223,12 @@ class TestIntegrationWorkflow:
         result = runner.invoke(app, ["path", "nonexistent"])
         assert result.exit_code == 1
 
-        # Remove .env.example and try to create
+        # Remove .env.example and try to create (should succeed now)
         (git_repo / ".env.example").unlink()
         result = runner.invoke(app, ["create", "another-branch"])
-        assert result.exit_code == 1
-        assert "No .env.example files found" in result.stdout
+        assert result.exit_code == 0
+        assert "Warning: No .env.example files found" in result.stdout
+        assert "Workspace 'another-branch' created successfully!" in result.stdout
 
         # Test outside git repo using a separate temp directory
         import tempfile


### PR DESCRIPTION
## Summary
- Modified `sprout create` to work in repositories without `.env.example` files
- Changed error behavior to show warning instead of exiting when no `.env.example` files found
- Updated documentation to reflect that `.env.example` files are optional
- Added comprehensive test coverage for new functionality

## Test plan
- [x] Unit tests pass for repositories without `.env.example` files
- [x] Integration tests verify end-to-end functionality
- [x] Existing functionality with `.env.example` files remains unchanged
- [x] Documentation updated to reflect new behavior
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)